### PR TITLE
fix to cd run into the fork when we have a '|'

### DIFF
--- a/microshell.c
+++ b/microshell.c
@@ -1,13 +1,13 @@
 #include "microshell.h"
 
-int err(char *str) 
+int err(char *str)
 {
     while (*str)
         write(2, str++, 1);
     return 1;
 }
 
-int cd(char **argv, int i) 
+int cd(char **argv, int i)
 {
     if (i != 2)
         return err("error: cd: bad arguments\n");
@@ -16,21 +16,26 @@ int cd(char **argv, int i)
     return 0;
 }
 
-int exec(char **argv, char **envp, int i) 
+int exec(char **argv, char **envp, int i)
 {
     int fd[2];
     int status;
     int has_pipe = argv[i] && !strcmp(argv[i], "|");
 
+    if (!has_pipe && !strcmp(*argv, "cd"))
+        return cd(argv, i);
+
     if (has_pipe && pipe(fd) == -1)
         return err("error: fatal\n");
 
     int pid = fork();
-    if (!pid) 
+    if (!pid)
     {
         argv[i] = 0;
         if (has_pipe && (dup2(fd[1], 1) == -1 || close(fd[0]) == -1 || close(fd[1]) == -1))
             return err("error: fatal\n");
+        if (!strcmp(*argv, "cd"))
+            return cd(argv, i);
         execve(*argv, argv, envp);
         return err("error: cannot execute "), err(*argv), err("\n");
     }
@@ -41,22 +46,20 @@ int exec(char **argv, char **envp, int i)
     return WIFEXITED(status) && WEXITSTATUS(status);
 }
 
-int main(int argc, char **argv, char **envp) 
+int main(int argc, char **argv, char **envp)
 {
     int    i = 0;
     int    status = 0;
 
-    if (argc > 1) 
+    if (argc > 1)
     {
-        while (argv[i] && argv[++i]) 
+        while (argv[i] && argv[++i])
         {
             argv += i;
             i = 0;
             while (argv[i] && strcmp(argv[i], "|") && strcmp(argv[i], ";"))
                 i++;
-            if (!strcmp(*argv, "cd"))
-                status = cd(argv, i);
-            else if (i)
+            if (i)
                 status = exec(argv, envp, i);
         }
     }


### PR DESCRIPTION
when we have a `cd` command and then a `|` the `cd` must run inside a fork so it doesn't affect its parent.

` ./microshell "cd" ".." ";" "/usr/bin/pwd"`
was having the same effect as
`./microshell "cd" ".." "|" "/usr/bin/pwd"`

now:
```
❯ cc microshell.c -o microshell
❯ ./microshell "cd" ".." ";" "/usr/bin/pwd"
/nfs/homes/bmoretti/Projects
❯ ./microshell "cd" ".." "|" "/usr/bin/pwd"
/nfs/homes/bmoretti/Projects/42-School-Exam-Rank-04
```