### PR TITLE
updated __environ variable for execve

### DIFF
--- a/microshell.c
+++ b/microshell.c
@@ -16,7 +16,7 @@ int cd(char **argv, int i)
     return 0;
 }
 
-int exec(char **argv, char **envp, int i)
+int exec(char **argv, int i)
 {
     int fd[2];
     int status;
@@ -36,7 +36,7 @@ int exec(char **argv, char **envp, int i)
             return err("error: fatal\n");
         if (!strcmp(*argv, "cd"))
             return cd(argv, i);
-        execve(*argv, argv, envp);
+        execve(*argv, argv, __environ);
         return err("error: cannot execute "), err(*argv), err("\n");
     }
 
@@ -46,7 +46,7 @@ int exec(char **argv, char **envp, int i)
     return WIFEXITED(status) && WEXITSTATUS(status);
 }
 
-int main(int argc, char **argv, char **envp)
+int main(int argc, char **argv)
 {
     int    i = 0;
     int    status = 0;
@@ -60,7 +60,7 @@ int main(int argc, char **argv, char **envp)
             while (argv[i] && strcmp(argv[i], "|") && strcmp(argv[i], ";"))
                 i++;
             if (i)
-                status = exec(argv, envp, i);
+                status = exec(argv, i);
         }
     }
     return status;


### PR DESCRIPTION
you don't really need to use 'char **envp' directly in main.
we have a variable provided by 'unistd.h' lib that's called `__environ` that have all environment variables that are needed to execve. (same of envp).