### PR TITLE
added extern variable environ

### DIFF
--- a/microshell.c
+++ b/microshell.c
@@ -2,6 +2,8 @@
 #include <unistd.h>
 #include <sys/wait.h>
 
+extern char **environ;
+
 int err(char *str)
 {
     while (*str)
@@ -38,7 +40,7 @@ int exec(char **argv, int i)
             return err("error: fatal\n");
         if (!strcmp(*argv, "cd"))
             return cd(argv, i);
-        execve(*argv, argv, __environ);
+        execve(*argv, argv, environ);
         return err("error: cannot execute "), err(*argv), err("\n");
     }
 


### PR DESCRIPTION
it is reported that using the `__environ` is not allowed in the test.
In general, it's recommended to use `environ` rather than `__environ`, because environ is standardized by POSIX and is more portable across different systems. The __environ variable is not standardized and might not be available on all systems.
I would advise to use:
```
extern char **environ;
```
which is not a global and it is posix compliant.
Also mentioned in the linux programming language by kerrisk (page 127), and he says it is better than using the char **env in main.