### PR TITLE
When using execve(), ensure platform compatibility.

### DIFF
--- a/microshell.c
+++ b/microshell.c
@@ -18,7 +18,7 @@ int cd(char **argv, int i)
     return 0;
 }
 
-int exec(char **argv, int i)
+int exec(char **argv, char **envp, int i)
 {
     int fd[2];
     int status;
@@ -38,7 +38,7 @@ int exec(char **argv, int i)
             return err("error: fatal\n");
         if (!strcmp(*argv, "cd"))
             return cd(argv, i);
-        execve(*argv, argv, __environ);
+        execve(*argv, argv, envp);
         return err("error: cannot execute "), err(*argv), err("\n");
     }
 
@@ -48,7 +48,7 @@ int exec(char **argv, int i)
     return WIFEXITED(status) && WEXITSTATUS(status);
 }
 
-int main(int argc, char **argv)
+int main(int argc, char **argv, char **envp)
 {
     int    i = 0;
     int    status = 0;
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
             while (argv[i] && strcmp(argv[i], "|") && strcmp(argv[i], ";"))
                 i++;
             if (i)
-                status = exec(argv, i);
+                status = exec(argv, envp, i);
         }
     }
     return status;


### PR DESCRIPTION
When using execve(), ensure platform compatibility. Although 'extern char **environ' is POSIX-compliant, it's flagged as unauthorized by grademe, resulting in a -42. Consider using the traditional 'char **envp' from main().