### PR TITLE
Envp variable used instead of forbidden extern char **environ

### DIFF
--- a/microshell.c
+++ b/microshell.c
@@ -2,8 +2,6 @@
 #include <unistd.h>
 #include <sys/wait.h>
 
-extern char **environ;
-
 int err(char *str)
 {
     while (*str)
@@ -20,7 +18,7 @@ int cd(char **argv, int i)
     return 0;
 }
 
-int exec(char **argv, int i)
+int exec(char **argv, int i, char **envp)
 {
     int fd[2];
     int status;
@@ -40,7 +38,7 @@ int exec(char **argv, int i)
             return err("error: fatal\n");
         if (!strcmp(*argv, "cd"))
             return cd(argv, i);
-        execve(*argv, argv, environ);
+        execve(*argv, argv, envp);
         return err("error: cannot execute "), err(*argv), err("\n");
     }
 
@@ -50,7 +48,7 @@ int exec(char **argv, int i)
     return WIFEXITED(status) && WEXITSTATUS(status);
 }
 
-int main(int argc, char **argv)
+int main(int argc, char **argv, char **envp)
 {
     int    i = 0;
     int    status = 0;
@@ -64,7 +62,7 @@ int main(int argc, char **argv)
             while (argv[i] && strcmp(argv[i], "|") && strcmp(argv[i], ";"))
                 i++;
             if (i)
-                status = exec(argv, i);
+                status = exec(argv, i, envp);
         }
     }
     return status;


### PR DESCRIPTION
Today (20/06/2024) I did the microshell exam on the 42 Barcelona campus. I memorized this code for the exam. Once I used the grademe command the exercise failed due to the use of the forbbiden environ variable. I only had to change it back to the classic envp variable received by main to make it work correctly. Im not sure if this new error is caused by this new migration to ubuntu linux or soemthing else, but I hope this helps.