### PR TITLE
Fix: Behebung von Compiler-Fehlern durch Hinzufügen von argc-Variable…

### DIFF
--- a/microshell.c
+++ b/microshell.c
@@ -52,8 +52,9 @@ int	exec(char **argv, int i, char **envp)
 	return WIFEXITED(status) && WEXITSTATUS(status);
 }
 
-int main(int, char **argv, char **envp)
+int main(int argc, char **argv, char **envp)
 {
+	(void)argc;
 	int i = 0, status = 0;
 
 	while (argv[i])


### PR DESCRIPTION
… in main()

- Die argc-Variable wurde als Parameter in die main-Funktion eingefügt, um Kompilierungsfehler zu verhindern.
- Da argc in der Funktion nicht verwendet wird, wurde (void)argc; hinzugefügt, um ungenutzte Variable zu vermeiden und dennoch erfolgreich zu kompilieren.