### PR TITLE
Resolve chdir usage warnings

### DIFF
--- a/microshell.c
+++ b/microshell.c
@@ -13,7 +13,7 @@ int cd(char **argv, int i)
 {
 	if (i != 2)
 		return err("error: cd: bad arguments\n"), 1;
-	if (chdir(argv[1]) == -1)
+	if (chdir(argv[1]) < 0)
 		return err("error: cd: cannot change directory to "), err(argv[1]), err("\n"), 1;
 	return 0;
 }


### PR DESCRIPTION
Your pull request description communicates the issue and the context, but it has some wording and clarity issues. Here's a polished and clearer version:

---

### Fix: Resolve `chdir` usage warnings in `microshell.c`

#### Problem:
The following code in `microshell.c` produces warnings due to incorrect comparison and type usage:

```c
if (chdir(argv[i] == -1))
```

**Warnings:**
```
microshell.c:16:22: warning: comparison between pointer and integer ('char *' and 'int') [-Wpointer-integer-compare]
if (chdir(argv[i] == -1))
            ~~~~ ^
microshell.c:16:14: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'const char *' [-Wincompatible-pointer-types]
if (chdir(argv[i] == -1))
             ^~~
/usr/include/unistd.h:517:31: note: passing argument to parameter '__path' here
extern int chdir (const char *__path) __THROW __nonnull ((1)) __wur;
2 warnings generated.
```

#### Cause:
- The comparison `argv[i] == -1` is incorrect because `argv[i]` is a `char*` (string), and `-1` is an integer.
- Passing the result of `argv[i] == -1` (which is a boolean `int`) to `chdir` causes type mismatches.

#### Fix:
The proper check is:
```c
if (chdir(argv[i]) < 0)
```

#### Explanation:
- `chdir` expects a `const char*` argument.
- The return value of `chdir` should be checked against `0` to detect errors (`< 0` indicates failure).