### PR TITLE
Update README to Correct err Function Signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ YEAH
 #include <stdlib.h>
 
 // Function to write an error message to stderr
-int err(char *str)
+void err(char *str)
 {
     // Loop through each character in the string and write it to stderr
     while (*str)


### PR DESCRIPTION
This pull request updates the err function signature in the repository's README to match the actual implementation in the microshell.c. Previously, the README incorrectly defined the err function as returning an int, whereas the implemented function returns void.